### PR TITLE
Messaging: fix some int'l numbers from displaying incorrectly

### DIFF
--- a/src/com/android/messaging/util/PhoneUtils.java
+++ b/src/com/android/messaging/util/PhoneUtils.java
@@ -886,22 +886,11 @@ public abstract class PhoneUtils {
                 phoneText.replaceAll("\\D", "").length() < MINIMUM_PHONE_NUMBER_LENGTH_TO_FORMAT) {
             return phoneText;
         }
-        final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
         final String systemCountry = getLocaleCountry();
-        final int systemCountryCode = phoneNumberUtil.getCountryCodeForRegion(systemCountry);
-        try {
-            final PhoneNumber parsedNumber = phoneNumberUtil.parse(phoneText, systemCountry);
-            final PhoneNumberFormat phoneNumberFormat =
-                    (systemCountryCode > 0 && parsedNumber.getCountryCode() == systemCountryCode) ?
-                            PhoneNumberFormat.NATIONAL : PhoneNumberFormat.INTERNATIONAL;
-            return BidiFormatter.getInstance().unicodeWrap(
-                    phoneNumberUtil.format(parsedNumber, phoneNumberFormat),
-                    TextDirectionHeuristicsCompat.LTR);
-        } catch (NumberParseException e) {
-            LogUtil.e(TAG, "PhoneUtils.formatForDisplay: invalid phone number "
-                    + LogUtil.sanitizePII(phoneText) + " with country " + systemCountry);
-            return phoneText;
-        }
+        String formatted = PhoneNumberUtils.formatNumber(phoneText,
+                PhoneNumberUtils.formatNumberToE164(phoneText, systemCountry), systemCountry);
+        return BidiFormatter.getInstance()
+                .unicodeWrap(formatted, TextDirectionHeuristicsCompat.LTR);
     }
 
     /**


### PR DESCRIPTION
The framework already handles a bunch of special cases and uses
libphonenumber to format the number.

Ticket: CYNGNOS-2945

Change-Id: If9b08b04b74bd1aa3b11214a42a15f7bfbc5ab48
Signed-off-by: Roman Birg <roman@cyngn.com>