### PR TITLE
really use the subId: PhoneAccountHandle

### DIFF
--- a/src/com/android/messaging/ui/conversation/ComposeMessageView.java
+++ b/src/com/android/messaging/ui/conversation/ComposeMessageView.java
@@ -87,6 +87,7 @@ import com.cyanogenmod.messaging.util.PrefsUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -244,7 +245,20 @@ public class ComposeMessageView extends LinearLayout
                     @Override
                     public void onPhoneAccountSelected(PhoneAccountHandle selectedAccountHandle,
                                                        boolean setDefault) {
-                        cb.onSimSelected(Integer.valueOf(selectedAccountHandle.getId()));
+                        // we need the subId and we only have a PhoneAccountHandle
+                        TelephonyManager telephonyManager =
+                            (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+                        Iterator<PhoneAccountHandle> phoneAccounts =
+                            telecomMgr.getCallCapablePhoneAccounts().listIterator();
+                        int subId = 0; // defaulting to 0, just in case
+                        while (phoneAccounts.hasNext()) {
+                            PhoneAccountHandle p = phoneAccounts.next();
+                            if (p.getId() == selectedAccountHandle.getId()) {
+                                PhoneAccount phoneAccount = telecomMgr.getPhoneAccount(p);
+                                subId = telephonyManager.getSubIdForPhoneAccount(phoneAccount);
+                            }
+                        }
+                        cb.onSimSelected(subId);
                     }
                     @Override
                     public void onDialogDismissed() {

--- a/src/com/cyanogenmod/messaging/quickmessage/QuickMessagePopup.java
+++ b/src/com/cyanogenmod/messaging/quickmessage/QuickMessagePopup.java
@@ -62,6 +62,7 @@ import com.cyanogenmod.messaging.ui.QuickMessageView;
 import com.cyanogenmod.messaging.util.PrefsUtils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class QuickMessagePopup extends Activity {
@@ -401,7 +402,20 @@ public class QuickMessagePopup extends Activity {
                     @Override
                     public void onPhoneAccountSelected(PhoneAccountHandle selectedAccountHandle,
                             boolean setDefault) {
-                        cb.onSimSelected(Integer.valueOf(selectedAccountHandle.getId()));
+                        // we need the subId and we only have a PhoneAccountHandle
+                        TelephonyManager telephonyManager =
+                            (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+                        Iterator<PhoneAccountHandle> phoneAccounts =
+                            telecomMgr.getCallCapablePhoneAccounts().listIterator();
+                        int subId = 0; // defaulting to 0, just in case
+                        while (phoneAccounts.hasNext()) {
+                            PhoneAccountHandle p = phoneAccounts.next();
+                            if (p.getId() == selectedAccountHandle.getId()) {
+                                PhoneAccount phoneAccount = telecomMgr.getPhoneAccount(p);
+                                subId = telephonyManager.getSubIdForPhoneAccount(phoneAccount);
+                            }
+                        }
+                        cb.onSimSelected(subId);
                     }
                     @Override
                     public void onDialogDismissed() {


### PR DESCRIPTION
PhoneAccountHandle's getId does *not* return subId, nor an int, but an
unique String identifier:

"A connection service must select identifiers that are stable for the
lifetime  of their users' relationship with their service, across many
Android devices.  For example, a good set of identifiers might be the
email addresses with which  with users registered for their accounts
with a particular service."

Not only onSimSelected is expecting to receive int subId, but more
importantly, if you try to
Integer.valueOf(selectedAccountHandle.getId()) you'll probably bump
into a few NumberFormatException's (if the identifier is an email
address, as the previous text suggests, this is what's going to
happen).

Fix this by actually using the subId for the PhoneAccount that has
that PhoneAccountHandle.

Change-Id: I366e25602db2f96ffb95192c7664993834ba99fc